### PR TITLE
refactor: replace angular.uppercase

### DIFF
--- a/src/api/Api.js
+++ b/src/api/Api.js
@@ -26,7 +26,7 @@ export default /* @ngInject */ function ($http, $q) {
   angular.forEach(['get', 'put', 'post', 'delete'], (operationType) => {
     self[operationType] = (url, opt) => {
       const options = angular.extend({}, opt);
-      options.method = angular.uppercase(operationType);
+      options.method = operationType.toUpperCase();
       options.url = url;
       return self.operation(options);
     };


### PR DESCRIPTION
replace angular.uppercase with vanilla JS toUpperCase since it's deprecated in angular 1.7.x

(we'll soon need this lib to be compatible with angular 1.7.x in order to import manager-web in our mono repo)