### PR TITLE
build(peer-deps): upgrade ng-ovh-http to v4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "stylelint-config-standard": "^18.2.0"
   },
   "peerDependencies": {
-    "@ovh-ux/ng-ovh-http": "^4.0.1-beta.0",
+    "@ovh-ux/ng-ovh-http": "^4.0.2",
     "@ovh-ux/ng-ovh-payment-method": "^1.1.1",
     "@ovh-ux/ng-ovh-swimming-poll": "^4.0.0",
     "@ovh-ux/ng-ovh-user-pref": "^1.0.0-beta.0",


### PR DESCRIPTION
# Upgrade ng-ovh-http to v4.0.2

## :arrow_up: Upgrade

9e4fa37 - build(peer-deps): upgrade ng-ovh-http to v4.0.2

## :link: Related

- https://github.com/ovh-ux/ng-ovh-http/commit/e8021da68c6308d381705a596ff1f9bfd998918d

## :house: Internal

- No QC required.